### PR TITLE
Improve TSLint rules

### DIFF
--- a/demo-app/tslint.json
+++ b/demo-app/tslint.json
@@ -81,7 +81,7 @@
         "variable-declaration": "nospace"
       }
     ],
-    "variable-name": false,
+    "variable-name": [true, "ban-keywords", "check-format"],
     "whitespace": [
       true,
       "check-branch",
@@ -105,6 +105,8 @@
     "no-access-missing-member": true,
     "templates-use-public": true,
     "invoke-injectable": true,
+
+    "ordered-imports": [true, {"import-sources-order": "case-insensitive", "named-imports-order": "case-insensitive"}],
 
     "block-spacing": true,
     "no-empty-interfaces": true,

--- a/src/app/button/button.component.view.spec.ts
+++ b/src/app/button/button.component.view.spec.ts
@@ -1,8 +1,8 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../shared/test-wrapper';
-import { MzButtonComponent } from './button.component';
 import { MzIconComponent } from '../icon/icon.component';
+import { buildComponent, MzTestWrapperComponent } from '../shared/test-wrapper';
+import { MzButtonComponent } from './button.component';
 
 describe('MzButtonComponent:view', () => {
 

--- a/src/app/card/card.component.view.spec.ts
+++ b/src/app/card/card.component.view.spec.ts
@@ -1,7 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../shared/test-wrapper';
 import { MzCardComponent } from './card.component';
 
 describe('MzCardComponent:view', () => {

--- a/src/app/icon/icon.component.view.spec.ts
+++ b/src/app/icon/icon.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../shared/test-wrapper';
 import { MzIconComponent } from './icon.component';
 
 describe('ButtonComponent:view', () => {

--- a/src/app/materialize.module.ts
+++ b/src/app/materialize.module.ts
@@ -1,5 +1,5 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import * as Button from './button/button.component';
 import * as Card from './card/card.component';

--- a/src/app/navbar/navbar-item-container/navbar-item-container.component.view.spec.ts
+++ b/src/app/navbar/navbar-item-container/navbar-item-container.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../../shared/test-wrapper';
 import { MzNavbarItemContainerComponent } from './navbar-item-container.component';
 
 describe('MzNavbarItemContainerComponent:view', () => {

--- a/src/app/navbar/navbar-item/navbar-item.component.view.spec.ts
+++ b/src/app/navbar/navbar-item/navbar-item.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../../shared/test-wrapper';
 import { MzNavbarItemComponent } from './navbar-item.component';
 
 describe('MzNavbarItemComponent:view', () => {

--- a/src/app/navbar/navbar.component.view.spec.ts
+++ b/src/app/navbar/navbar.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../shared/test-wrapper';
 import { MzNavbarComponent } from './navbar.component';
 
 describe('MzNavbarComponent:view', () => {

--- a/src/app/parallax/parallax.component.view.spec.ts
+++ b/src/app/parallax/parallax.component.view.spec.ts
@@ -1,7 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../shared/test-wrapper';
 import { MzParallaxComponent } from './parallax.component';
 
 describe('MzParallaxComponent:view', () => {

--- a/src/app/progress/progress.component.view.spec.ts
+++ b/src/app/progress/progress.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../shared/test-wrapper';
 import { MzProgressComponent } from './progress.component';
 
 describe('MzProgressComponent:view', () => {

--- a/src/app/shared/test-wrapper/test-wrapper.module.ts
+++ b/src/app/shared/test-wrapper/test-wrapper.module.ts
@@ -1,6 +1,6 @@
 // Need this module to prevent error 'Cannot determine the module for class TestWrapperComponent' with AoT compiling
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
 import { MzTestWrapperComponent } from './test-wrapper.component';
 

--- a/src/app/sidenav/sidenav-collapsible/sidenav-collapsible.component.view.spec.ts
+++ b/src/app/sidenav/sidenav-collapsible/sidenav-collapsible.component.view.spec.ts
@@ -1,7 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../../shared/test-wrapper';
 import { MzSidenavCollapsibleComponent } from './sidenav-collapsible.component';
 
 describe('MzSidenavCollapsibleComponent:view', () => {

--- a/src/app/sidenav/sidenav-divider/sidenav-divider.component.view.spec.ts
+++ b/src/app/sidenav/sidenav-divider/sidenav-divider.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../../shared/test-wrapper';
 import { MzSidenavDividerComponent } from './sidenav-divider.component';
 
 describe('MzSidenavDividerComponent:view', () => {

--- a/src/app/sidenav/sidenav-header/sidenav-header.component.view.spec.ts
+++ b/src/app/sidenav/sidenav-header/sidenav-header.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../../shared/test-wrapper';
 import { MzSidenavHeaderComponent } from './sidenav-header.component';
 
 describe('MzSidenavHeaderComponent:view', () => {

--- a/src/app/sidenav/sidenav-link/sidenav-link.component.view.spec.ts
+++ b/src/app/sidenav/sidenav-link/sidenav-link.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../../shared/test-wrapper';
 import { MzSidenavLinkComponent } from './sidenav-link.component';
 
 describe('MzSidenavLinkComponent:view', () => {

--- a/src/app/sidenav/sidenav-subheader/sidenav-subheader.component.view.spec.ts
+++ b/src/app/sidenav/sidenav-subheader/sidenav-subheader.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../../shared/test-wrapper';
 import { MzSidenavSubheaderComponent } from './sidenav-subheader.component';
 
 describe('MzSidenavSubheaderComponent:view', () => {

--- a/src/app/sidenav/sidenav.component.view.spec.ts
+++ b/src/app/sidenav/sidenav.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../shared/test-wrapper';
 import { MzSidenavComponent } from './sidenav.component';
 
 describe('MzSidenavComponent:view', () => {

--- a/src/app/spinner/spinner.component.unit.spec.ts
+++ b/src/app/spinner/spinner.component.unit.spec.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-unused-variable */
+import { DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
 
 import { MzSpinnerComponent } from './spinner.component';
 

--- a/src/app/spinner/spinner.component.view.spec.ts
+++ b/src/app/spinner/spinner.component.view.spec.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { MzTestWrapperComponent, buildComponent } from '../shared/test-wrapper';
+import { buildComponent, MzTestWrapperComponent } from '../shared/test-wrapper';
 import { MzSpinnerComponent } from './spinner.component';
 
 describe('MzSpinnerComponent:view', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,10 @@
 import './polyfills.ts';
 
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
-import { environment } from './environments/environment';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
 import { MaterializeModule } from './app/';
+import { environment } from './environments/environment';
 
 if (environment.production) {
   enableProdMode();

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,19 +1,19 @@
 // This file includes polyfills needed by Angular 2 and is loaded before
 // the app. You can add your own extra polyfills to this file.
-import 'core-js/es6/symbol';
-import 'core-js/es6/object';
-import 'core-js/es6/function';
-import 'core-js/es6/parse-int';
-import 'core-js/es6/parse-float';
-import 'core-js/es6/number';
-import 'core-js/es6/math';
-import 'core-js/es6/string';
-import 'core-js/es6/date';
 import 'core-js/es6/array';
-import 'core-js/es6/regexp';
+import 'core-js/es6/date';
+import 'core-js/es6/function';
 import 'core-js/es6/map';
-import 'core-js/es6/set';
+import 'core-js/es6/math';
+import 'core-js/es6/number';
+import 'core-js/es6/object';
+import 'core-js/es6/parse-float';
+import 'core-js/es6/parse-int';
 import 'core-js/es6/reflect';
+import 'core-js/es6/regexp';
+import 'core-js/es6/set';
+import 'core-js/es6/string';
+import 'core-js/es6/symbol';
 
 import 'core-js/es7/reflect';
 import 'zone.js/dist/zone';

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:ordered-imports */
 import './polyfills.ts';
 
 import 'zone.js/dist/long-stack-trace-zone';
@@ -6,6 +7,7 @@ import 'zone.js/dist/sync-test';
 import 'zone.js/dist/jasmine-patch';
 import 'zone.js/dist/async-test';
 import 'zone.js/dist/fake-async-test';
+
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/tslint.json
+++ b/tslint.json
@@ -81,7 +81,7 @@
         "variable-declaration": "nospace"
       }
     ],
-    "variable-name": false,
+    "variable-name": [true, "ban-keywords", "check-format"],
     "whitespace": [
       true,
       "check-branch",
@@ -105,6 +105,8 @@
     "no-access-missing-member": true,
     "templates-use-public": true,
     "invoke-injectable": true,
+
+    "ordered-imports": [true, {"import-sources-order": "case-insensitive", "named-imports-order": "case-insensitive"}],
 
     "block-spacing": true,
     "no-empty-interfaces": true,


### PR DESCRIPTION
Added the following rules : 

### variable-name
- Allows only camelCased or UPPER_CASED variable names,.
- Disallows the use of certain TypeScript keywords.

### ordered-imports
Enforce a consistent ordering for ES6 imports: - Named imports must be alphabetized in case-insensitive (i.e. “import {A, b, C} from “foo”;”).