### PR TITLE
Replace JQuery with Renderer.invokeElementMethod in Parallax component

### DIFF
--- a/src/app/parallax/parallax.component.ts
+++ b/src/app/parallax/parallax.component.ts
@@ -20,12 +20,7 @@ export class MzParallaxComponent implements AfterViewInit {
   constructor(public renderer: Renderer) { }
 
   ngAfterViewInit(): void {
-    // set parallax height
-    this.renderer.setElementStyle(
-      this.parallaxContainer.nativeElement,
-      'height',
-      isNaN(this.height) ? '500px' : this.height + 'px');
-    // initialize parallax element
-    $(this.parallax.nativeElement).parallax();
+    this.renderer.setElementStyle(this.parallaxContainer.nativeElement, 'height', isNaN(this.height) ? '500px' : this.height + 'px');
+    this.renderer.invokeElementMethod($(this.parallax.nativeElement), 'parallax');
   }
 }

--- a/src/app/parallax/parallax.component.unit.spec.ts
+++ b/src/app/parallax/parallax.component.unit.spec.ts
@@ -55,12 +55,22 @@ describe('MzParallaxComponent:unit', () => {
 
     it('shoul initialize parallax using jquery', () => {
 
-      const parallaxSpy = spyOn($.fn, 'parallax');
+      const mockJQueryParallaxNativeElement = { parallax: true };
+
+      spyOn(component.renderer, 'invokeElementMethod');
+
+      spyOn(window, '$').and.callFake((selector: any) => {
+        return selector === component.parallax.nativeElement
+          ? mockJQueryParallaxNativeElement
+          : {};
+      });
 
       component.ngAfterViewInit();
 
-      expect(parallaxSpy).toHaveBeenCalledTimes(1);
-      expect(parallaxSpy.calls.mostRecent().object.context).toBe(component.parallax.nativeElement);
+      expect(component.renderer.invokeElementMethod)
+        .toHaveBeenCalledWith(
+          mockJQueryParallaxNativeElement,
+          'parallax');
     });
   });
 });


### PR DESCRIPTION
Replaced the use of JQuery to invoke parallax initialization with Renderer.setInvokeMethod and adjusted the unit test