### PR TITLE
Removed autofocus on Button demo-app page

### DIFF
--- a/demo-app/src/app/button/button.component.html
+++ b/demo-app/src/app/button/button.component.html
@@ -206,7 +206,6 @@
   <div class="col s12 m3">
     <button mz-button
       type="submit"
-      autofocus
       (click)="this.clicked($event)"
     >
       button


### PR DESCRIPTION
Fix behavior where navigating to Button demo page for the first time show page already scrolled down to submit button example