### PR TITLE
Fix mdi icon offset + new properties mz-icon-mdi

### DIFF
--- a/demo-app/src/app/collapsible/collapsible.component.html
+++ b/demo-app/src/app/collapsible/collapsible.component.html
@@ -7,7 +7,7 @@
   <mz-collapsible class="col s12 m8 l6" mode="accordion">
 
     <mz-collapsible-item *ngFor="let item of simpleCollapsibleItems">
-      <mz-collapsible-item-header>{{ item.header }}</mz-collapsible-item-header>
+      <mz-collapsible-item-header><i mz-icon-mdi [icon]="item.icon"></i>{{ item.header }}</mz-collapsible-item-header>
       <mz-collapsible-item-body><p>{{ item.body }}</p></mz-collapsible-item-body>
     </mz-collapsible-item>
 

--- a/demo-app/src/app/collapsible/collapsible.component.ts
+++ b/demo-app/src/app/collapsible/collapsible.component.ts
@@ -12,27 +12,30 @@ import { ROUTE_ANIMATION, ROUTE_ANIMATION_HOST } from '../app.routes.animation';
 export class CollapsibleComponent {
   public simpleCollapsibleItems = [
     {
+      icon: 'cloud',
       header: 'First',
       body: `
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
-        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation 
-        ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur 
-        adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim 
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum 
-        dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna 
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
         aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.`,
 
     },
     {
+      icon: 'flash',
       header: 'Second',
       body: `
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.`,
     },
     {
+      icon: 'gamepad',
       header: 'Third',
       body: `
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.`,
     },
   ];

--- a/demo-app/src/app/icon/icon.component.html
+++ b/demo-app/src/app/icon/icon.component.html
@@ -42,6 +42,7 @@
 
   <app-code-snippet>
 &lt;i mz-icon
+  [align]="'right'"
   [icon]="'cloud'"
   [size]="'medium'">
 &lt;/i>
@@ -87,11 +88,52 @@
     </p>
   </div>
 
+  <div class="row m-valign-wrapper">
+    <i mz-icon-mdi
+      class="col s12 m2"
+      [flip]="'horizontal'"
+      [icon]="'sword'">
+    </i>
+
+    <p class="col s12 m10">
+      <code class="language-markup">icon</code> property as <code class="language-markup">sword</code> and <code class="language-markup">horizontal</code> flip
+    </p>
+  </div>
+
+  <div class="row m-valign-wrapper">
+    <i mz-icon-mdi
+      class="col s12 m2"
+      [icon]="'sword'"
+      [rotate]="'180'">
+    </i>
+
+    <p class="col s12 m10">
+      <code class="language-markup">icon</code> property as <code class="language-markup">sword</code> and <code class="language-markup">rotate</code> to 90 degree
+    </p>
+  </div>
+
+  <div class="row m-valign-wrapper">
+    <a mz-icon-mdi
+      class="col s12 m2"
+      [icon]="'puzzle'"
+      [size]="'18px'"
+      href="#">
+      Link
+    </a>
+
+    <p class="col s12 m10">
+      <code class="language-markup">mz-icon-mdi</code> directive added to <code class="language-markup">a</code> tag
+    </p>
+  </div>
+
   <h5 class="light">HTML Structure</h5>
 
   <app-code-snippet>
 &lt;i mz-icon-mdi
+  [align]="'right'"
+  [flip]="'vertical'"
   [icon]="'puzzle'"
+  [rotate]="'45'"
   [size]="'36px'">
 &lt;/i>
   </app-code-snippet>
@@ -121,7 +163,14 @@
         <td>align</td>
         <td class="center grey-text"><i mz-icon-mdi [icon]="'minus'"></i></td>
         <td>string</td>
-        <td>Alignement of the icon</td>
+        <td>Alignement of the icon. It could be <code class="language-markup">center</code>, <code class="language-markup">left</code> or <code class="language-markup">right</code></td>
+        <td>left</td>
+      </tr>
+      <tr>
+        <td>flip</td>
+        <td class="center grey-text"><i mz-icon-mdi [icon]="'minus'"></i></td>
+        <td>string</td>
+        <td>Flip the icon. It could be <code class="language-markup">horizontal</code> or <code class="language-markup">vertical</code><br /><strong>(Only for <code class="language-markup">mz-icon-mdi</code>)</strong>
         <td></td>
       </tr>
       <tr>
@@ -132,10 +181,18 @@
         <td></td>
       </tr>
       <tr>
+        <td>rotate</td>
+        <td class="center grey-text"><i mz-icon-mdi [icon]="'minus'"></i></td>
+        <td>string</td>
+        <td>Rotate the icon by 45 degree increments. It could be <code class="language-markup">45</code>, <code class="language-markup">90</code>, <code class="language-markup">135</code>, <code class="language-markup">180</code>, <code class="language-markup">225</code>,
+        <code class="language-markup">270</code> or <code class="language-markup">315</code><br /><strong>(Only for <code class="language-markup">mz-icon-mdi</code>)</strong>
+        <td></td>
+      </tr>
+      <tr>
         <td>size</td>
         <td class="center grey-text"><i mz-icon-mdi [icon]="'minus'"></i></td>
         <td>string</td>
-        <td>Icon size to be applied on the icon. <br />For <code class="language-markup">mz-icon</code> directive <code class="language-markup">tiny</code>, <code class="language-markup">small</code>, <code class="language-markup">medium</code> and <code class="language-markup">large</code>.<br /> For <code class="language-markup">mz-icon-mdi</code> directive it could be could be <code class="language-markup">24px</code>, <code class="language-markup">36px</code>, or <code class="language-markup">48px</code></td>
+        <td>Icon size to be applied on the icon. <br />For <code class="language-markup">mz-icon</code> directive <code class="language-markup">tiny</code>, <code class="language-markup">small</code>, <code class="language-markup">medium</code> and <code class="language-markup">large</code>.<br /> For <code class="language-markup">mz-icon-mdi</code> directive it could be could be <code class="language-markup">18px</code>, <code class="language-markup">24px</code>, <code class="language-markup">36px</code>, or <code class="language-markup">48px</code></td>
         <td>Default value for <code class="language-markup">mz-icon-mdi</code> is <code class="language-markup">24px</code></td>
       </tr>
     </tbody>

--- a/demo-app/src/app/sidenav/sidenav.component.html
+++ b/demo-app/src/app/sidenav/sidenav.component.html
@@ -54,7 +54,11 @@
     <mz-sidenav-divider></mz-sidenav-divider>
 
     <mz-sidenav-link>
-      <a><i class="mdi mdi-cloud mdi-24px"></i>Third Link With Icon</a>
+      <a><i mz-icon-mdi [icon]="'cloud'"></i>Third Link With Icon</a>
+    </mz-sidenav-link>
+
+    <mz-sidenav-link>
+      <a mz-icon-mdi [icon]="'cloud'">Fourth Link With Icon</a>
     </mz-sidenav-link>
 
     <mz-sidenav-divider></mz-sidenav-divider>
@@ -86,7 +90,7 @@
     <mz-sidenav-collapsible>
 
       <mz-sidenav-collapsible-header>
-        Collapsible With Carret<i class="caret mdi mdi-menu-right mdi-24px"></i>
+        <i mz-icon-mdi [icon]="'menu-right'" class="caret"></i>Collapsible With Carret
       </mz-sidenav-collapsible-header>
 
       <mz-sidenav-collapsible-content>
@@ -108,13 +112,13 @@
     <mz-sidenav-collapsible>
 
       <mz-sidenav-collapsible-header>
-        <i class="mdi mdi-cloud mdi-24px"></i>Collapsible With Icon
+        <i mz-icon-mdi [icon]="'cloud'"></i>Collapsible With Icon
       </mz-sidenav-collapsible-header>
 
       <mz-sidenav-collapsible-content>
 
         <mz-sidenav-link>
-          <a class="waves-effect">First Link</a>
+          <a class="waves-effect"><i mz-icon-mdi [icon]="'cloud'"></i>Link</a>
         </mz-sidenav-link>
 
         <mz-sidenav-link>
@@ -170,7 +174,7 @@
 &lt;mz-sidenav>
   &lt;mz-sidenav-collapsible>
     &lt;mz-sidenav-collapsible-header>
-      Collapsible
+       &lt;i mz-icon-mdi [icon]="'menu-right'" class="caret">&lt;/i>Collapsible
     &lt;/mz-sidenav-collapsible-header>
     &lt;mz-sidenav-collapsible-content>
       &lt;mz-sidenav-link>

--- a/demo-app/src/app/sidenav/sidenav.component.scss
+++ b/demo-app/src/app/sidenav/sidenav.component.scss
@@ -24,8 +24,6 @@
 :host #{'/deep/'} {
   a {
     i.caret {
-      float: right;
-      margin-right: -10px;
       -ms-transition: 0.2s;
       -webkit-transition: 0.2s;
       -o-transition:  0.2s;

--- a/src/app/icon/iconmdi.directive.ts
+++ b/src/app/icon/iconmdi.directive.ts
@@ -9,11 +9,14 @@ import {
 import { HandlePropChanges } from '../shared/handle-prop-changes';
 
 @Directive({
-  selector: 'i[mz-icon-mdi], i[mzIconMdi]',
+  selector: '[mz-icon-mdi], [mzIconMdi]',
+
 })
 export class MzIconMdiDirective extends HandlePropChanges implements AfterViewInit {
   @Input() align: string;
+  @Input() flip: string;
   @Input() icon: string;
+  @Input() rotate: string;
   @Input() size: string;
 
   constructor(private elementRef: ElementRef, private renderer: Renderer) {
@@ -29,7 +32,9 @@ export class MzIconMdiDirective extends HandlePropChanges implements AfterViewIn
   initHandlers() {
     this.handlers = {
       align: () => this.handleAlign(),
+      flip: () => this.handleFlip(),
       icon: () => this.handleIcon(),
+      rotate: () => this.handleRotate(),
       size: () => this.handleSize(),
     };
   }
@@ -42,8 +47,16 @@ export class MzIconMdiDirective extends HandlePropChanges implements AfterViewIn
     this.renderer.setElementClass(this.elementRef.nativeElement, this.align, !!this.align);
   }
 
+  handleFlip() {
+    this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-flip-' + this.flip, !!this.flip);
+  }
+
   handleIcon() {
     this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-' + this.icon, true);
+  }
+
+  handleRotate() {
+    this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-rotate-' + this.rotate, !!this.rotate);
   }
 
   handleSize() {

--- a/src/app/icon/iconmdi.directive.unit.spec.ts
+++ b/src/app/icon/iconmdi.directive.unit.spec.ts
@@ -63,7 +63,9 @@ describe('MzIconMdiDirective:unit', () => {
 
       const handlers = {
          align: 'handleAlign',
+         flip: 'handleFlip',
          icon: 'handleIcon',
+         rotate: 'handleRotate',
          size: 'handleSize',
       };
 
@@ -118,6 +120,29 @@ describe('MzIconMdiDirective:unit', () => {
     });
   });
 
+  describe('handleFlip', () => {
+
+    it('should add flip css class when flip is provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      directive.flip = 'vertical';
+
+      directive.handleFlip();
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-flip-' + directive.flip, true);
+    });
+
+    it('should not add flip css class when flip is not provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      directive.handleFlip();
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-flip-' + directive.flip, false);
+    });
+  });
+
   describe('handleIcon', () => {
 
     it('should add icon to the icon tag class attribute', () => {
@@ -129,6 +154,29 @@ describe('MzIconMdiDirective:unit', () => {
       directive.handleIcon();
 
       expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-' + directive.icon, true);
+    });
+  });
+
+  describe('handleRotate', () => {
+
+    it('should add rotate css class when flip is provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      directive.rotate = '90';
+
+      directive.handleRotate();
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-rotate-' + directive.rotate, true);
+    });
+
+    it('should not add rotate css class when flip is not provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      directive.handleRotate();
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-rotate-' + directive.rotate, false);
     });
   });
 

--- a/src/app/sidenav/sidenav-collapsible/sidenav-collapsible.component.scss
+++ b/src/app/sidenav/sidenav-collapsible/sidenav-collapsible.component.scss
@@ -6,6 +6,19 @@
 
 :host #{'/deep/'} {
   .collapsible-header {
+
+    a[class*="mdi-"],
+    i.material-icons,
+    i[class*="mdi-"], {
+      /* Fix for mz-sidenav-collapsible-header content who does not get icon CSS from li > a > i */
+      float: left;
+      height: 48px;
+      line-height: 48px;
+      margin: -1px 1.5rem 0 0;
+      width: 24px;
+      color: rgba(0, 0, 0, 0.54);
+    }
+
     i {
       color: rgba(0,0,0,0.54);
     }

--- a/src/app/sidenav/sidenav-link/sidenav-link.component.scss
+++ b/src/app/sidenav/sidenav-link/sidenav-link.component.scss
@@ -1,9 +1,15 @@
 :host #{'/deep/'} {
+  a[class*="mdi-"]::before {
+    color: rgba(0, 0, 0, 0.54);
+    margin: -1px 1.5rem 0 0;
+    vertical-align: middle;
+  }
+
   a {
     i,
     i.material-icons,
     i[class*="mdi-"] {
-      margin-right: 1.5em;
+      margin: -1px 1.5rem 0 0;
 
       &::before {
         vertical-align: middle;

--- a/src/app/sidenav/sidenav.component.scss
+++ b/src/app/sidenav/sidenav.component.scss
@@ -14,12 +14,4 @@
       @include hz-box-shadow;
     }
   }
-
-  li {
-    a {
-      i[class*="mdi-"] {
-        margin: 0.3em 1em 0 0;
-      }
-    }
-  }
 }


### PR DESCRIPTION
- Add flip and rotate properties to mz-icon-mdi directive.
- Add SCSS style when mz-icon-mdi is used on <a></a> tag
- Fix mdi icon offset in sidenav.
- Fix margin for collapsible in sidenav.
- Fix icon CSS properties in collapsible header. It could use css from Materializecss because of the mz-sidenav-collapsible-header selector.
- Remove unused class in sidenac scss.