### PR TITLE
Handle async option changes on select

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,5 @@
 
   // Removes the leading ./ character when the path is pointing to a parent folder.
   "relativePath.removeLeadingDot": true,
-  "vsicons.presets.angular": true
+  "vsicons.presets.angular": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,5 @@
 
   // Removes the leading ./ character when the path is pointing to a parent folder.
   "relativePath.removeLeadingDot": true,
-  "vsicons.presets.angular": false
+  "vsicons.presets.angular": true
 }

--- a/demo-app/src/app/select/select.component.html
+++ b/demo-app/src/app/select/select.component.html
@@ -193,6 +193,28 @@
 
 <div class="section">
 
+  <h5 class="light">Async options</h5>
+
+  <div class="row m-valign-wrapper">
+
+    <mz-select-container class="col s12 m6">
+      <select mz-select
+        id="async-options-select"
+        [label]="'Label'"
+        [placeholder]="'Placeholder'"
+      >
+        <option *ngFor="let option of selectAsyncOptions | async" [selected]="option === optionValue">{{ option }}</option>
+      </select>
+    </mz-select-container>
+
+    <p class="col s12 m6">
+      Pass your async options to property <code class="language-markup">options</code>.
+    </p>
+  </div>
+</div>
+
+<div class="section">
+
   <h5 class="light">Playground</h5>
 
   <p>

--- a/demo-app/src/app/select/select.component.ts
+++ b/demo-app/src/app/select/select.component.ts
@@ -1,4 +1,7 @@
+import 'rxjs/add/operator/delay';
+
 import { Component } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
 
 import { ROUTE_ANIMATION, ROUTE_ANIMATION_HOST } from '../app.routing.animation';
 import { IPropertyRow } from '../shared/properties-table/properties-table.component';
@@ -47,4 +50,14 @@ export class SelectComponent {
       defaultValue: `false`,
     },
   ];
+
+  selectAsyncOptions = new Observable((observer) => {
+    observer.next([
+      'Option 1',
+      'Option 2',
+      'Option 3',
+      'Option 4',
+    ]);
+    observer.complete();
+  }).delay(500);
 }

--- a/demo-app/src/app/select/select.module.ts
+++ b/demo-app/src/app/select/select.module.ts
@@ -12,7 +12,7 @@ import { SelectComponent } from './select.component';
     CodeSnippetModule,
     CommonModule,
     FormsModule,
-    MaterializeModule.forRoot(),
+    MaterializeModule,
     PropertiesTableModule,
   ],
   declarations: [SelectComponent],

--- a/src/app/select/select.directive.ts
+++ b/src/app/select/select.directive.ts
@@ -38,7 +38,7 @@ export class MzSelectDirective extends HandlePropChanges implements AfterViewIni
 
   suspend = false;
 
-  lastOptions: HTMLCollection;
+  lastOptions: Element[];
 
   constructor(
     private elementRef: ElementRef,
@@ -105,7 +105,7 @@ export class MzSelectDirective extends HandlePropChanges implements AfterViewIni
       setTimeout(() => this.selectElement.val(selectedOptions));
 
       // prevent close on first multi select change
-      this.lastOptions = this.selectElement[0].children;
+      this.lastOptions = Array.from(this.selectElement[0].children);
     }
   }
 
@@ -220,7 +220,7 @@ export class MzSelectDirective extends HandlePropChanges implements AfterViewIni
     Observable.fromEvent($(this.selectElement), 'DOMSubtreeModified')
       .debounceTime(100)
       .filter((event: JQueryEventObject) => {
-        const currentOptions: any = Array.from(event.currentTarget.children);
+        const currentOptions = Array.from(event.currentTarget.children);
 
         if (this.lastOptions) {
           const prevOptions = Array.from(this.lastOptions);
@@ -229,7 +229,7 @@ export class MzSelectDirective extends HandlePropChanges implements AfterViewIni
           if (prevOptions.length !== currentOptions.length) {
             return true;
           } else {
-            return currentOptions.some((option: Element, index) =>
+            return currentOptions.some((option, index) =>
               !prevOptions[index] || option.textContent !== prevOptions[index].textContent);
           }
         } else {

--- a/src/app/select/select.directive.unit.spec.ts
+++ b/src/app/select/select.directive.unit.spec.ts
@@ -701,4 +701,33 @@ describe('MzSelectDirective:unit', () => {
       });
     });
   });
+
+  describe('optionElementsLength', () => {
+
+    let mockSelect: HTMLSelectElement;
+
+    beforeEach(() => {
+      mockSelect = document.createElement('select');
+      directive.selectElement = $(mockSelect);
+    });
+
+    it('should return the right option length without placeholder', () => {
+      mockSelect.appendChild(document.createElement('option'));
+      mockSelect.appendChild(document.createElement('option'));
+
+      directive.placeholder = undefined;
+
+      expect(directive.optionElementsLength()).toBe(2);
+    });
+
+    it('should return the right option length with placeholder', () => {
+      mockSelect.appendChild(document.createElement('option')); // insert placeholder manually
+      mockSelect.appendChild(document.createElement('option'));
+      mockSelect.appendChild(document.createElement('option'));
+
+      directive.placeholder = 'some-placeholder';
+
+      expect(directive.optionElementsLength()).toBe(2);
+    });
+  });
 });

--- a/src/app/select/select.directive.unit.spec.ts
+++ b/src/app/select/select.directive.unit.spec.ts
@@ -66,8 +66,9 @@ describe('MzSelectDirective:unit', () => {
     beforeEach(() => {
       directive.selectElement = <any>mockSelectElement;
       spyOn(directive, 'initOnChange');
-      spyOn(directive, 'initFilledIn');
+      spyOn(directive, 'listenOptionChanges');
       spyOn(directive, 'initMultiple');
+      spyOn(directive, 'initFilledIn');
     });
 
     it('should invoke material_select method on select element for initialization', () => {
@@ -82,6 +83,12 @@ describe('MzSelectDirective:unit', () => {
       directive.ngAfterViewInit();
 
       expect(directive.initFilledIn).toHaveBeenCalled();
+    });
+
+    it('should call listenOptionChanges', () => {
+      directive.ngAfterViewInit();
+
+      expect(directive.listenOptionChanges).toHaveBeenCalled();
     });
 
     it('should call initMultiple', () => {
@@ -169,6 +176,22 @@ describe('MzSelectDirective:unit', () => {
 
       expect(directive.selectElement.val).not.toHaveBeenCalled();
     }));
+
+    it('should set lastOptions', () => {
+      const mockSelect = document.createElement('select');
+      mockSelect.multiple = true;
+      mockSelect.appendChild(createOption('option-1', false));
+      mockSelect.appendChild(createOption('option-2', false));
+      mockSelect.appendChild(createOption('option-3', true));
+
+      directive.selectElement = $(mockSelect);
+
+      expect(directive.lastOptions).toBe(undefined);
+
+      directive.initMultiple();
+
+      expect(directive.lastOptions).toEqual(Array.from(directive.selectElement[0].children));
+    });
   });
 
   describe('initOnChange', () => {

--- a/src/app/select/select.directive.unit.spec.ts
+++ b/src/app/select/select.directive.unit.spec.ts
@@ -701,33 +701,4 @@ describe('MzSelectDirective:unit', () => {
       });
     });
   });
-
-  describe('optionElementsLength', () => {
-
-    let mockSelect: HTMLSelectElement;
-
-    beforeEach(() => {
-      mockSelect = document.createElement('select');
-      directive.selectElement = $(mockSelect);
-    });
-
-    it('should return the right option length without placeholder', () => {
-      mockSelect.appendChild(document.createElement('option'));
-      mockSelect.appendChild(document.createElement('option'));
-
-      directive.placeholder = undefined;
-
-      expect(directive.optionElementsLength()).toBe(2);
-    });
-
-    it('should return the right option length with placeholder', () => {
-      mockSelect.appendChild(document.createElement('option')); // insert placeholder manually
-      mockSelect.appendChild(document.createElement('option'));
-      mockSelect.appendChild(document.createElement('option'));
-
-      directive.placeholder = 'some-placeholder';
-
-      expect(directive.optionElementsLength()).toBe(2);
-    });
-  });
 });

--- a/src/app/select/select.directive.view.spec.ts
+++ b/src/app/select/select.directive.view.spec.ts
@@ -48,9 +48,7 @@ describe('MzSelectDirective:view', () => {
 
         fixture.detectChanges();
 
-        fixture.whenStable().then(() => {
-          expect(optionLength()).toBe(1 + 2);
-        });
+        expect(optionLength()).toBe(1 + 2);
       });
     }));
   });

--- a/src/app/select/select.directive.view.spec.ts
+++ b/src/app/select/select.directive.view.spec.ts
@@ -1,0 +1,57 @@
+import { async, TestBed } from '@angular/core/testing';
+
+import { buildComponent, MzTestWrapperComponent } from '../shared/test-wrapper';
+import { MzSelectContainerComponent, MzSelectDirective } from './';
+
+describe('MzSelectDirective:view', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        MzSelectContainerComponent,
+        MzSelectDirective,
+        MzTestWrapperComponent,
+      ],
+    });
+  }));
+
+  describe('option changes', () => {
+
+    let nativeElement: any;
+
+    it('should sync materialize select with native select when properties is updated', async(() => {
+
+      const selectAsyncOptions = ['Option 1'];
+
+      buildComponent<any>(`
+        <mz-select-container>
+          <select mz-select
+            id="async-options-select"
+            [label]="'Label'"
+            [placeholder]="'Placeholder'"
+          >
+            <option *ngFor="let option of selectAsyncOptions" [selected]="option === optionValue">{{ option }}</option>
+          </select>
+        </mz-select-container>
+      `, {
+        selectAsyncOptions,
+      }).then((fixture) => {
+
+        nativeElement = fixture.nativeElement;
+        fixture.detectChanges();
+
+        const optionLength = () => fixture.nativeElement.querySelectorAll('option').length;
+
+        expect(optionLength()).toBe(1 + 1);
+
+        fixture.componentInstance.selectAsyncOptions = ['Option 1', 'Option 2'];
+
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+          expect(optionLength()).toBe(1 + 2);
+        });
+      });
+    }));
+  });
+});


### PR DESCRIPTION
Fixes #88.

There's an issue with select options when they're async, the native select was updated but the changes was not reflected to the select materialized.

This PR partially fix this issue by subscribing to the `DOMSubtreeModified` event on select element and count options to notice any changes, if the options count doesn't match, it trigger a `material_select`, then changes are reflected to the select materialized.

~~While this solution works for a majority of use cases without adding any properties to the select, it doesn't cover when options are changed without modifying the length of the options array (ex: trigger translation). These use cases should be handle manually.~~

_Edited :_ Fix now cover every use cases by keeping the last options and compare on every DOM changes. 

Also, we can't do a real test case with `Observable.delay` because of an issue in Zone.js, it should be fixed by the latest release of zone.js. I'll verify that after we've updated our dependencies.