### PR TITLE
Test on Firefox and IE with AppVeyor

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@
 /.editorconfig
 /.npmignore
 /.vscode
+/app.json
 /app/shared/test-wrapper
 /appveyor.yml
 /circle.yml
@@ -18,6 +19,7 @@
 /karma.conf.js
 /protractor.conf.js
 /src
+/static.json
 /test-results.xml
 /tsconfig.json
 /tslint-formatters

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ test_script:
   - node --version
   - npm --version
   - yarn --version
-  - yarn test -- --single-run
+  - yarn test -- --single-run --browsers Chrome,Firefox,IE
   - yarn lint
   - yarn build
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,6 +8,8 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
+      require('karma-firefox-launcher'),
+      require('karma-ie-launcher'),
       require('karma-junit-reporter'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "karma-chrome-launcher": "~2.0.0",
     "karma-cli": "~1.0.1",
     "karma-coverage-istanbul-reporter": "^0.2.0",
+    "karma-firefox-launcher": "^1.0.1",
+    "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-junit-reporter": "^1.2.0",

--- a/src/app/badge/badge.component.view.spec.ts
+++ b/src/app/badge/badge.component.view.spec.ts
@@ -27,7 +27,7 @@ describe('MzBadgeComponent:view', () => {
         fixture.detectChanges();
 
         expect(badge()).toBeTruthy();
-        expect(badge().innerText).toBe('2');
+        expect(badge().innerText.trim()).toBe('2');
       });
     }));
 

--- a/src/app/media/media.service.unit.spec.ts
+++ b/src/app/media/media.service.unit.spec.ts
@@ -25,89 +25,96 @@ describe('MzMediaService:unit', () => {
 
   describe('media', () => {
 
-    it('should return observable media on window resize', async(() => {
-      const useCases = [
-        { alias: 's', windowHeight: 0, windowWidth: 0 },
-        { alias: 's', windowHeight: 400, windowWidth: 600 },
-        { alias: 'm', windowHeight: 400, windowWidth: 601 },
-        { alias: 'm', windowHeight: 680, windowWidth: 992 },
-        { alias: 'l', windowHeight: 680, windowWidth: 993 },
-        { alias: 'l', windowHeight: 960, windowWidth: 1200 },
-        { alias: 'xl', windowHeight: 960, windowWidth: 1201 },
-        { alias: 'xl', windowHeight: 1080, windowWidth: 1920 },
-        { alias: 'xl', windowHeight: 99999, windowWidth: 99999 },
-      ];
+    // disable this test on IE as mock window doesn't work that way on IE
+    if (!/Trident/.test(window.navigator.userAgent)) {
+      it('should return observable media on window resize', async(() => {
 
-      // need subscribition for observable.fromEvent to be triggered
-      mediaService.media.subscribe();
+        const useCases = [
+          { alias: 's', windowHeight: 0, windowWidth: 0 },
+          { alias: 's', windowHeight: 400, windowWidth: 600 },
+          { alias: 'm', windowHeight: 400, windowWidth: 601 },
+          { alias: 'm', windowHeight: 680, windowWidth: 992 },
+          { alias: 'l', windowHeight: 680, windowWidth: 993 },
+          { alias: 'l', windowHeight: 960, windowWidth: 1200 },
+          { alias: 'xl', windowHeight: 960, windowWidth: 1201 },
+          { alias: 'xl', windowHeight: 1080, windowWidth: 1920 },
+          { alias: 'xl', windowHeight: 99999, windowWidth: 99999 },
+        ];
 
-      useCases.forEach(useCase => {
-        mockWindowSize(useCase.windowHeight, useCase.windowWidth);
+        // need subscribition for observable.fromEvent to be triggered
+        mediaService.media.subscribe();
 
-        window.dispatchEvent(new Event('resize'));
+        useCases.forEach(useCase => {
+          mockWindowSize(useCase.windowHeight, useCase.windowWidth);
 
-        mediaService.media.first().subscribe(media => {
-          expect(media.alias).toBe(useCase.alias);
-          expect(media.windowHeight).toBe(useCase.windowHeight);
-          expect(media.windowWidth).toBe(useCase.windowWidth);
+          window.dispatchEvent(new Event('resize'));
+
+          mediaService.media.first().subscribe(media => {
+            expect(media.alias).toBe(useCase.alias);
+            expect(media.windowHeight).toBe(useCase.windowHeight);
+            expect(media.windowWidth).toBe(useCase.windowWidth);
+          });
         });
-      });
-    }));
+      }));
+    }
   });
 
   describe('isActive', () => {
 
-    it('should return observable boolean on window resize', async(() => {
+    // disable this test on IE as mock window doesn't work that way on IE
+    if (!/Trident/.test(window.navigator.userAgent)) {
+      it('should return observable boolean on window resize', async(() => {
 
-      const useCases = [
-        // small
-        { alias: 'lt-s', windowWidth: 0, isActive: false },
-        { alias: 's', windowWidth: 0, isActive: true },
-        { alias: 's', windowWidth: 600, isActive: true },
-        { alias: 's', windowWidth: 601, isActive: false },
-        { alias: 'gt-s', windowWidth: 600, isActive: false },
-        { alias: 'gt-s', windowWidth: 601, isActive: true },
-        { alias: 'gt-s', windowWidth: 9999, isActive: true },
-        // medium
-        { alias: 'lt-m', windowWidth: 0, isActive: true },
-        { alias: 'lt-m', windowWidth: 600, isActive: true },
-        { alias: 'lt-m', windowWidth: 601, isActive: false },
-        { alias: 'm', windowWidth: 600, isActive: false },
-        { alias: 'm', windowWidth: 601, isActive: true },
-        { alias: 'm', windowWidth: 992, isActive: true },
-        { alias: 'm', windowWidth: 993, isActive: false },
-        { alias: 'gt-m', windowWidth: 992, isActive: false },
-        { alias: 'gt-m', windowWidth: 993, isActive: true },
-        { alias: 'gt-m', windowWidth: 9999, isActive: true },
-        // large
-        { alias: 'lt-l', windowWidth: 0, isActive: true },
-        { alias: 'lt-l', windowWidth: 992, isActive: true },
-        { alias: 'lt-l', windowWidth: 993, isActive: false },
-        { alias: 'l', windowWidth: 992, isActive: false },
-        { alias: 'l', windowWidth: 993, isActive: true },
-        { alias: 'l', windowWidth: 1200, isActive: true },
-        { alias: 'l', windowWidth: 1201, isActive: false },
-        { alias: 'gt-l', windowWidth: 1200, isActive: false },
-        { alias: 'gt-l', windowWidth: 1201, isActive: true },
-        { alias: 'gt-l', windowWidth: 9999, isActive: true },
-        // xlarge
-        { alias: 'lt-xl', windowWidth: 0, isActive: true },
-        { alias: 'lt-xl', windowWidth: 1200, isActive: true },
-        { alias: 'lt-xl', windowWidth: 1201, isActive: false },
-        { alias: 'xl', windowWidth: 1200, isActive: false },
-        { alias: 'xl', windowWidth: 1201, isActive: true },
-        { alias: 'xl', windowWidth: Number.MAX_VALUE, isActive: true },
-        { alias: 'gt-xl', windowWidth: Number.MAX_VALUE, isActive: false },
-      ];
+        const useCases = [
+          // small
+          { alias: 'lt-s', windowWidth: 0, isActive: false },
+          { alias: 's', windowWidth: 0, isActive: true },
+          { alias: 's', windowWidth: 600, isActive: true },
+          { alias: 's', windowWidth: 601, isActive: false },
+          { alias: 'gt-s', windowWidth: 600, isActive: false },
+          { alias: 'gt-s', windowWidth: 601, isActive: true },
+          { alias: 'gt-s', windowWidth: 9999, isActive: true },
+          // medium
+          { alias: 'lt-m', windowWidth: 0, isActive: true },
+          { alias: 'lt-m', windowWidth: 600, isActive: true },
+          { alias: 'lt-m', windowWidth: 601, isActive: false },
+          { alias: 'm', windowWidth: 600, isActive: false },
+          { alias: 'm', windowWidth: 601, isActive: true },
+          { alias: 'm', windowWidth: 992, isActive: true },
+          { alias: 'm', windowWidth: 993, isActive: false },
+          { alias: 'gt-m', windowWidth: 992, isActive: false },
+          { alias: 'gt-m', windowWidth: 993, isActive: true },
+          { alias: 'gt-m', windowWidth: 9999, isActive: true },
+          // large
+          { alias: 'lt-l', windowWidth: 0, isActive: true },
+          { alias: 'lt-l', windowWidth: 992, isActive: true },
+          { alias: 'lt-l', windowWidth: 993, isActive: false },
+          { alias: 'l', windowWidth: 992, isActive: false },
+          { alias: 'l', windowWidth: 993, isActive: true },
+          { alias: 'l', windowWidth: 1200, isActive: true },
+          { alias: 'l', windowWidth: 1201, isActive: false },
+          { alias: 'gt-l', windowWidth: 1200, isActive: false },
+          { alias: 'gt-l', windowWidth: 1201, isActive: true },
+          { alias: 'gt-l', windowWidth: 9999, isActive: true },
+          // xlarge
+          { alias: 'lt-xl', windowWidth: 0, isActive: true },
+          { alias: 'lt-xl', windowWidth: 1200, isActive: true },
+          { alias: 'lt-xl', windowWidth: 1201, isActive: false },
+          { alias: 'xl', windowWidth: 1200, isActive: false },
+          { alias: 'xl', windowWidth: 1201, isActive: true },
+          { alias: 'xl', windowWidth: Number.MAX_VALUE, isActive: true },
+          { alias: 'gt-xl', windowWidth: Number.MAX_VALUE, isActive: false },
+        ];
 
-      useCases.forEach(useCase => {
-        mockWindowSize(0, useCase.windowWidth);
+        useCases.forEach(useCase => {
+          mockWindowSize(0, useCase.windowWidth);
 
-        mediaService.isActive(useCase.alias).first().subscribe(isActive => {
-          expect(isActive).toBe(useCase.isActive);
+          mediaService.isActive(useCase.alias).first().subscribe(isActive => {
+            expect(isActive).toBe(useCase.isActive);
+          });
         });
-      });
-    }));
+      }));
+    }
 
     it('should log error when media is invalid', () => {
 

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -18,20 +18,22 @@
  * BROWSER POLYFILLS
  */
 
+/* tslint:disable: ordered-imports */
+
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
-// import 'core-js/es6/symbol';
-// import 'core-js/es6/object';
-// import 'core-js/es6/function';
-// import 'core-js/es6/parse-int';
-// import 'core-js/es6/parse-float';
-// import 'core-js/es6/number';
-// import 'core-js/es6/math';
-// import 'core-js/es6/string';
-// import 'core-js/es6/date';
-// import 'core-js/es6/array';
-// import 'core-js/es6/regexp';
-// import 'core-js/es6/map';
-// import 'core-js/es6/set';
+import 'core-js/es6/symbol';
+import 'core-js/es6/object';
+import 'core-js/es6/function';
+import 'core-js/es6/parse-int';
+import 'core-js/es6/parse-float';
+import 'core-js/es6/number';
+import 'core-js/es6/math';
+import 'core-js/es6/string';
+import 'core-js/es6/date';
+import 'core-js/es6/array';
+import 'core-js/es6/regexp';
+import 'core-js/es6/map';
+import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2961,6 +2961,16 @@ karma-coverage-istanbul-reporter@^0.2.0:
   dependencies:
     istanbul-api "^1.1.1"
 
+karma-firefox-launcher@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-1.0.1.tgz#ce58f47c2013a88156d55a5d61337c099cf5bb51"
+
+karma-ie-launcher@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/karma-ie-launcher/-/karma-ie-launcher-1.0.0.tgz#497986842c490190346cd89f5494ca9830c6d59c"
+  dependencies:
+    lodash "^4.6.1"
+
 karma-jasmine-html-reporter@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-0.2.2.tgz#48a8e5ef18807617ee2b5e33c1194c35b439524c"
@@ -3251,7 +3261,7 @@ lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -5778,16 +5788,9 @@ write-file-atomic@^1.1.2:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-ws@1.1.1:
+ws@1.1.1, ws@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.1.tgz#082ddb6c641e85d4bb451f03d52f06eabdb1f018"
-  dependencies:
-    options ">=0.0.5"
-    ultron "1.0.x"
-
-ws@^1.0.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"


### PR DESCRIPTION
As we support Firefox and IE as well, I added Firefox and IE launcher in Karma.

They'll run on AppVeyor with unlimited concurrency.

Unfortunately, I had to disable some `ModalService` tests because they're mocking read-only properties and it's not allowed in IE.