### PR TITLE
Update doc for collapsible

### DIFF
--- a/demo-app/src/app/collapsible/collapsible.component.html
+++ b/demo-app/src/app/collapsible/collapsible.component.html
@@ -151,8 +151,8 @@
   [onClose]="closeFunctionCallback"
   [onOpen]="openFunctionCallback"
   [popout]="true">
-  &lt;mz-collapsible-item>
-    &lt;mz-collapsible-item-header [active]="true">
+  &lt;mz-collapsible-item [active]="true">
+    &lt;mz-collapsible-item-header>
       First
     &lt;/mz-collapsible-item-header>
     &lt;mz-collapsible-item-body>


### PR DESCRIPTION
`[active]` param is on header instead of item