### PR TITLE
Fixed *ngFor for checkbox and radio-button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # compiled output
 /dist
+/documentation
 /tmp
 /out-tsc
 /out

--- a/src/app/checkbox/checkbox.directive.ts
+++ b/src/app/checkbox/checkbox.directive.ts
@@ -1,14 +1,11 @@
-import { Directive, ElementRef, Input, OnInit, Renderer } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Input, Renderer } from '@angular/core';
 
 import { HandlePropChanges } from '../shared/handle-prop-changes';
 
 @Directive({
   selector: 'input[mzCheckbox], input[mz-checkbox]',
 })
-export class MzCheckboxDirective extends HandlePropChanges implements OnInit {
-  // native properties
-  @Input() id: string;
-
+export class MzCheckboxDirective extends HandlePropChanges implements AfterViewInit {
   // directive properties
   @Input() filledIn: boolean;
   @Input() label: string;
@@ -21,7 +18,7 @@ export class MzCheckboxDirective extends HandlePropChanges implements OnInit {
     super();
   }
 
-  ngOnInit() {
+  ngAfterViewInit() {
     this.initHandlers();
     this.initElements();
     this.handleProperties();
@@ -42,7 +39,7 @@ export class MzCheckboxDirective extends HandlePropChanges implements OnInit {
 
   createLabelElement() {
     const labelElement = document.createElement('label');
-    labelElement.setAttribute('for', this.id);
+    labelElement.setAttribute('for', this.checkboxElement.attr('id'));
 
     this.renderer.invokeElementMethod(this.checkboxContainerElement, 'append', [labelElement]);
 

--- a/src/app/checkbox/checkbox.directive.unit.spec.ts
+++ b/src/app/checkbox/checkbox.directive.unit.spec.ts
@@ -22,7 +22,7 @@ describe('MzCheckboxDirective:unit', () => {
     directive = new MzCheckboxDirective(mockElementRef, renderer);
   });
 
-  describe('ngOnInit', () => {
+  describe('ngAfterViewInit', () => {
     let callOrder: string[];
 
     beforeEach(() => {
@@ -34,7 +34,7 @@ describe('MzCheckboxDirective:unit', () => {
 
     it('should call initHandlers method', () => {
 
-      directive.ngOnInit();
+      directive.ngAfterViewInit();
 
       expect(directive.initHandlers).toHaveBeenCalled();
       expect(callOrder[0]).toBe('initHandlers');
@@ -42,7 +42,7 @@ describe('MzCheckboxDirective:unit', () => {
 
     it('should call initElements method', () => {
 
-      directive.ngOnInit();
+      directive.ngAfterViewInit();
 
       expect(directive.initElements).toHaveBeenCalled();
       expect(callOrder[1]).toBe('initElements');
@@ -50,7 +50,7 @@ describe('MzCheckboxDirective:unit', () => {
 
     it('should call handleProperties method', () => {
 
-      directive.ngOnInit();
+      directive.ngAfterViewInit();
 
       expect(directive.handleProperties).toHaveBeenCalled();
       expect(callOrder[2]).toBe('handleProperties');
@@ -120,11 +120,12 @@ describe('MzCheckboxDirective:unit', () => {
       spyOn(renderer, 'invokeElementMethod');
 
       const checkboxId = 'checkbox-id';
+      const mockCheckboxElement = { checkbox: true, attr: (attributeName: string) => attributeName === 'id' ? checkboxId : null };
       const mockCheckboxContainerElement = { checkboxContainer: true };
       const mockLabelElement = document.createElement('label');
       mockLabelElement.setAttribute('for', checkboxId);
 
-      directive.id = checkboxId;
+      directive.checkboxElement = <any>mockCheckboxElement
       directive.checkboxContainerElement = <any>mockCheckboxContainerElement;
       directive.createLabelElement();
 
@@ -134,6 +135,7 @@ describe('MzCheckboxDirective:unit', () => {
     it('should return the newly created element', () => {
 
       const checkboxId = 'checkbox-id';
+      const mockCheckboxElement = { checkbox: true, attr: (attributeName: string) => attributeName === 'id' ? checkboxId : null };
       const mockLabelElement = document.createElement('label');
       mockLabelElement.setAttribute('for', checkboxId);
 
@@ -145,7 +147,7 @@ describe('MzCheckboxDirective:unit', () => {
           : {};
       });
 
-      directive.id = checkboxId;
+      directive.checkboxElement = <any>mockCheckboxElement;
       const jQuerylabelElement = directive.createLabelElement();
 
       expect(jQuerylabelElement).toBe(mockJQueryLabelElement);

--- a/src/app/radio-button/radio-button.directive.ts
+++ b/src/app/radio-button/radio-button.directive.ts
@@ -1,14 +1,11 @@
-import { Directive, ElementRef, Input, OnInit, Renderer } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Input, Renderer } from '@angular/core';
 
 import { HandlePropChanges } from '../shared/handle-prop-changes';
 
 @Directive({
   selector: 'input[mzRadioButton], input[mz-radio-button]',
 })
-export class MzRadioButtonDirective extends HandlePropChanges implements OnInit {
-  // native properties
-  @Input() id: string;
-
+export class MzRadioButtonDirective extends HandlePropChanges implements AfterViewInit {
   // directive properties
   @Input() label: string;
   @Input() withGap: boolean;
@@ -21,7 +18,7 @@ export class MzRadioButtonDirective extends HandlePropChanges implements OnInit 
     super();
   }
 
-  ngOnInit() {
+  ngAfterViewInit() {
     this.initHandlers();
     this.initElements();
     this.handleProperties();
@@ -42,7 +39,7 @@ export class MzRadioButtonDirective extends HandlePropChanges implements OnInit 
 
   createLabelElement() {
     const labelElement = document.createElement('label');
-    labelElement.setAttribute('for', this.id);
+    labelElement.setAttribute('for', this.inputElement.attr('id'));
 
     this.renderer.invokeElementMethod(this.inputContainerElement, 'append', [labelElement]);
 

--- a/src/app/radio-button/radio-button.directive.unit.spec.ts
+++ b/src/app/radio-button/radio-button.directive.unit.spec.ts
@@ -22,7 +22,7 @@ describe('MzRadioButtonDirective:unit', () => {
     directive = new MzRadioButtonDirective(mockElementRef, renderer);
   });
 
-  describe('ngOnInit', () => {
+  describe('ngAfterViewInit', () => {
     let callOrder: string[];
 
     beforeEach(() => {
@@ -34,7 +34,7 @@ describe('MzRadioButtonDirective:unit', () => {
 
     it('should call initHandlers method', () => {
 
-      directive.ngOnInit();
+      directive.ngAfterViewInit();
 
       expect(directive.initHandlers).toHaveBeenCalled();
       expect(callOrder[0]).toBe('initHandlers');
@@ -42,7 +42,7 @@ describe('MzRadioButtonDirective:unit', () => {
 
     it('should call initElements method', () => {
 
-      directive.ngOnInit();
+      directive.ngAfterViewInit();
 
       expect(directive.initElements).toHaveBeenCalled();
       expect(callOrder[1]).toBe('initElements');
@@ -50,7 +50,7 @@ describe('MzRadioButtonDirective:unit', () => {
 
     it('should call handleProperties method', () => {
 
-      directive.ngOnInit();
+      directive.ngAfterViewInit();
 
       expect(directive.handleProperties).toHaveBeenCalled();
       expect(callOrder[2]).toBe('handleProperties');
@@ -120,11 +120,12 @@ describe('MzRadioButtonDirective:unit', () => {
       spyOn(renderer, 'invokeElementMethod');
 
       const inputId = 'input-id';
+      const mockInputElement = { input: true, attr: (attributeName: string) => attributeName === 'id' ? inputId : null };
       const mockInputContainerElement = { inputContainer: true };
       const mockLabelElement = document.createElement('label');
       mockLabelElement.setAttribute('for', inputId);
 
-      directive.id = inputId;
+      directive.inputElement = <any>mockInputElement;
       directive.inputContainerElement = <any>mockInputContainerElement;
       directive.createLabelElement();
 
@@ -134,6 +135,7 @@ describe('MzRadioButtonDirective:unit', () => {
     it('should return the newly created element', () => {
 
       const inputId = 'input-id';
+      const mockInputElement = { input: true, attr: (attributeName: string) => attributeName === 'id' ? inputId : null };
       const mockLabelElement = document.createElement('label');
       mockLabelElement.setAttribute('for', inputId);
 
@@ -145,7 +147,7 @@ describe('MzRadioButtonDirective:unit', () => {
           : {};
       });
 
-      directive.id = inputId;
+      directive.inputElement = <any>mockInputElement;
       const jQuerylabelElement = directive.createLabelElement();
 
       expect(jQuerylabelElement).toBe(mockJQueryLabelElement);


### PR DESCRIPTION
Fix behavior where we were unable to select a value with checkbox and radio-button when using *ngFor on mz-x-container (#121)