### PR TITLE
Fix mz-icon and mz-icon-mdi input property changes

### DIFF
--- a/src/app/icon/icon-mdi.directive.ts
+++ b/src/app/icon/icon-mdi.directive.ts
@@ -10,7 +10,6 @@ import { HandlePropChanges } from '../shared/handle-prop-changes';
 
 @Directive({
   selector: '[mz-icon-mdi], [mzIconMdi]',
-
 })
 export class MzIconMdiDirective extends HandlePropChanges implements AfterViewInit {
   @Input() align: string;
@@ -31,11 +30,11 @@ export class MzIconMdiDirective extends HandlePropChanges implements AfterViewIn
 
   initHandlers() {
     this.handlers = {
-      align: () => this.handleAlign(),
-      flip: () => this.handleFlip(),
-      icon: () => this.handleIcon(),
-      rotate: () => this.handleRotate(),
-      size: () => this.handleSize(),
+      align: (previousValue) => this.handleAlign(previousValue),
+      flip: (previousValue) => this.handleFlip(previousValue),
+      icon: (previousValue) => this.handleIcon(previousValue),
+      rotate: (previousValue) => this.handleRotate(previousValue),
+      size: (previousValue) => this.handleSize(previousValue),
     };
   }
 
@@ -43,27 +42,41 @@ export class MzIconMdiDirective extends HandlePropChanges implements AfterViewIn
     this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi', true);
   }
 
-  handleAlign() {
+  handleAlign(previousValue?: string) {
+    if (previousValue) {
+      this.renderer.setElementClass(this.elementRef.nativeElement, previousValue, false);
+    }
     this.renderer.setElementClass(this.elementRef.nativeElement, this.align, !!this.align);
   }
 
-  handleFlip() {
+  handleFlip(previousValue?: string) {
+    if (previousValue) {
+      this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-flip-' + previousValue, false);
+    }
     this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-flip-' + this.flip, !!this.flip);
   }
 
-  handleIcon() {
+  handleIcon(previousValue?: string) {
+    if (previousValue) {
+      this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-' + previousValue, false);
+    }
     this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-' + this.icon, true);
   }
 
-  handleRotate() {
+  handleRotate(previousValue?: string) {
+    if (previousValue) {
+      this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-rotate-' + previousValue, false);
+    }
     this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-rotate-' + this.rotate, !!this.rotate);
   }
 
-  handleSize() {
+  handleSize(previousValue?: string) {
     if (!this.size) {
       this.size = '24px';
     }
-
+    if (previousValue) {
+      this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-' + previousValue, false);
+    }
     this.renderer.setElementClass(this.elementRef.nativeElement, 'mdi-' + this.size, true);
   }
 }

--- a/src/app/icon/icon-mdi.directive.unit.spec.ts
+++ b/src/app/icon/icon-mdi.directive.unit.spec.ts
@@ -75,12 +75,13 @@ describe('MzIconMdiDirective:unit', () => {
 
       Object.keys(handlers).forEach(key => {
         const handler = handlers[key];
+        const previousValue = 'previous-value';
 
         spyOn(directive, handler);
 
-        directive[handler]();
+        directive[handler](previousValue);
 
-        expect(directive[handler]).toHaveBeenCalled();
+        expect(directive[handler]).toHaveBeenCalledWith(previousValue);
       });
     });
   });
@@ -118,6 +119,17 @@ describe('MzIconMdiDirective:unit', () => {
 
       expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, directive.align, false);
     });
+
+    it('should remove previous css class when provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      const previousValue = 'previous-align-value';
+
+      directive.handleAlign(previousValue);
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, previousValue, false);
+    });
   });
 
   describe('handleFlip', () => {
@@ -141,6 +153,17 @@ describe('MzIconMdiDirective:unit', () => {
 
       expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-flip-' + directive.flip, false);
     });
+
+    it('should remove previous css class when provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      const previousValue = 'previous-flip-value';
+
+      directive.handleFlip(previousValue);
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-flip-' + previousValue, false);
+    });
   });
 
   describe('handleIcon', () => {
@@ -154,6 +177,17 @@ describe('MzIconMdiDirective:unit', () => {
       directive.handleIcon();
 
       expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-' + directive.icon, true);
+    });
+
+    it('should remove previous css class when provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      const previousValue = 'previous-icon-value';
+
+      directive.handleIcon(previousValue);
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-' + previousValue, false);
     });
   });
 
@@ -178,6 +212,17 @@ describe('MzIconMdiDirective:unit', () => {
 
       expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-rotate-' + directive.rotate, false);
     });
+
+    it('should remove previous css class when provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      const previousValue = 'previous-rotate-value';
+
+      directive.handleRotate(previousValue);
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-rotate-' + previousValue, false);
+    });
   });
 
   describe('handleSize', () => {
@@ -200,6 +245,17 @@ describe('MzIconMdiDirective:unit', () => {
       directive.handleSize();
 
       expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-24px', true);
+    });
+
+    it('should remove previous css class when provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      const previousValue = 'previous-size-value';
+
+      directive.handleSize(previousValue);
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, 'mdi-' + previousValue, false);
     });
   });
 });

--- a/src/app/icon/icon.directive.ts
+++ b/src/app/icon/icon.directive.ts
@@ -28,9 +28,9 @@ export class MzIconDirective extends HandlePropChanges implements AfterViewInit 
 
   initHandlers() {
     this.handlers = {
-      align: () => this.handleAlign(),
+      align: (previousValue) => this.handleAlign(previousValue),
       icon: () => this.handleIcon(),
-      size: () => this.handleSize(),
+      size: (previousValue) => this.handleSize(previousValue),
     };
   }
 
@@ -38,7 +38,10 @@ export class MzIconDirective extends HandlePropChanges implements AfterViewInit 
     this.renderer.setElementClass(this.elementRef.nativeElement, 'material-icons', true);
   }
 
-  handleAlign() {
+  handleAlign(previousValue?: string) {
+    if (previousValue) {
+      this.renderer.setElementClass(this.elementRef.nativeElement, previousValue, false);
+    }
     this.renderer.setElementClass(this.elementRef.nativeElement, this.align, !!this.align);
   }
 
@@ -46,7 +49,10 @@ export class MzIconDirective extends HandlePropChanges implements AfterViewInit 
     this.renderer.setElementProperty(this.elementRef.nativeElement, 'innerHTML', this.icon);
   }
 
-  handleSize() {
+  handleSize(previousValue?: string) {
+    if (previousValue) {
+      this.renderer.setElementClass(this.elementRef.nativeElement, previousValue, false);
+    }
     this.renderer.setElementClass(this.elementRef.nativeElement, this.size, !!this.size);
   }
 }

--- a/src/app/icon/icon.directive.unit.spec.ts
+++ b/src/app/icon/icon.directive.unit.spec.ts
@@ -73,12 +73,13 @@ describe('MzIconDirective:unit', () => {
 
       Object.keys(handlers).forEach(key => {
         const handler = handlers[key];
+        const previousValue = 'previous-value';
 
         spyOn(directive, handler);
 
-        directive[handler]();
+        directive[handler](previousValue);
 
-        expect(directive[handler]).toHaveBeenCalled();
+        expect(directive[handler]).toHaveBeenCalledWith(previousValue);
       });
     });
   });
@@ -116,6 +117,17 @@ describe('MzIconDirective:unit', () => {
 
       expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, directive.align, false);
     });
+
+    it('should remove previous css class when provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      const previousValue = 'previous-align-value';
+
+      directive.handleAlign(previousValue);
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, previousValue, false);
+    });
   });
 
   describe('handleIcon', () => {
@@ -152,6 +164,17 @@ describe('MzIconDirective:unit', () => {
       directive.handleSize();
 
       expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, directive.size, false);
+    });
+
+    it('should remove previous css class when provided', () => {
+
+      spyOn(renderer, 'setElementClass');
+
+      const previousValue = 'previous-size-value';
+
+      directive.handleSize(previousValue);
+
+      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, previousValue, false);
     });
   });
 });

--- a/src/app/shared/handle-prop-changes.ts
+++ b/src/app/shared/handle-prop-changes.ts
@@ -1,7 +1,11 @@
-import { OnChanges, SimpleChanges } from '@angular/core';
+import { OnChanges, SimpleChange, SimpleChanges } from '@angular/core';
+
+export abstract class Handlers {
+   [propertyName: string]: Function;
+}
 
 export class HandlePropChanges implements OnChanges {
-  handlers: Object;
+  handlers: Handlers;
 
   ngOnChanges(changes: SimpleChanges) {
     if (this.handlers) {
@@ -9,10 +13,11 @@ export class HandlePropChanges implements OnChanges {
     }
   }
 
-  executePropHandlers(props = this.handlers) {
-    Object.keys(props).forEach((prop) => {
+  executePropHandlers(props: Handlers | SimpleChanges = this.handlers) {
+    Object.keys(props).forEach(prop => {
       if (this.handlers[prop]) {
-        this.handlers[prop]();
+        const previousValue = (props[prop] as SimpleChange).previousValue;
+        this.handlers[prop](previousValue);
       }
     });
   }


### PR DESCRIPTION
Fix behavior where chaging mz-icon and mz-icon-mdi input properties dynamicaly (such as icon, align, flip, size, ...)  would not be reflected into the DOM (#97)