### PR TITLE
Update mz-icon-mdi flip property documentation

### DIFF
--- a/demo-app/src/app/icon/icon.component.html
+++ b/demo-app/src/app/icon/icon.component.html
@@ -92,13 +92,13 @@
     <span class="col s12 m2">
       <i mz-icon-mdi
         [align]="'left'"
-        [flip]="'horizontal'"
+        [flip]="'h'"
         [icon]="'sword'">
       </i>
     </span>
 
     <p class="col s12 m10">
-      <code class="language-markup">icon</code> property as <code class="language-markup">sword</code> and <code class="language-markup">horizontal</code> flip
+      <code class="language-markup">icon</code> property as <code class="language-markup">sword</code> and <code class="language-markup">flip</code> to <code class="language-markup">h</code> (horizontal)
     </p>
   </div>
 
@@ -135,7 +135,7 @@
   <app-code-snippet>
 &lt;i mz-icon-mdi
   [align]="'right'"
-  [flip]="'vertical'"
+  [flip]="'v'"
   [icon]="'puzzle'"
   [rotate]="'45'"
   [size]="'36px'">

--- a/demo-app/src/app/icon/icon.component.ts
+++ b/demo-app/src/app/icon/icon.component.ts
@@ -23,8 +23,8 @@ export class IconComponent {
       mandatory: false,
       type: 'string',
       description: `<strong>Only for <code class="language-markup">mz-icon-mdi</code></strong><br />
-        Flip the icon. Possible values: <code class="language-markup">horizontal</code> or
-        <code class="language-markup">vertical</code>`,
+        Flip the icon. Possible values: <code class="language-markup">h</code> (horizontal) or
+        <code class="language-markup">v</code> (vertical)`,
     },
     { name: 'icon',
       mandatory: true,


### PR DESCRIPTION
Material Design Icon (mdi) renamed the possible values for flip: [https://github.com/Templarian/MaterialDesign-Webfont/issues/31](https://github.com/Templarian/MaterialDesign-Webfont/issues/31#issuecomment-291535563)
