### PR TITLE
Fix autocomplete and validation when loading input demo page

### DIFF
--- a/demo-app/src/app/input/input.component.ts
+++ b/demo-app/src/app/input/input.component.ts
@@ -1,4 +1,8 @@
 import { AfterViewInit, Component, OnInit, Renderer } from '@angular/core';
+import 'rxjs/add/observable/interval';
+import 'rxjs/add/operator/first';
+import 'rxjs/add/operator/skipWhile';
+import { Observable } from 'rxjs/Observable';
 
 import { ROUTE_ANIMATION, ROUTE_ANIMATION_HOST } from '../app.routing.animation';
 import { IPropertyRow } from '../shared/properties-table/properties-table.component';
@@ -95,8 +99,12 @@ export class InputComponent implements AfterViewInit, OnInit {
   }
 
   forceValidate() {
-    // need setTimeout otherwise loading directly on the page doesn't trigger the validation
-    setTimeout(() => this.renderer.invokeElementMethod($('#valid-input, #invalid-input'), 'trigger', ['blur']));
+    // need until window.validate_field is defined otherwise loading directly on the page doesn't trigger the validation
+    Observable
+      .interval(100)
+      .skipWhile(() => !window['validate_field'])
+      .first()
+      .subscribe(() => this.renderer.invokeElementMethod($('#valid-input, #invalid-input'), 'trigger', ['blur']));
   }
 
   setAutocomplete() {

--- a/demo-app/yarn.lock
+++ b/demo-app/yarn.lock
@@ -284,13 +284,9 @@ alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
 
-amdefine@1.0.0:
+amdefine@1.0.0, amdefine@>=0.0.4:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.0.tgz#fd17474700cb5cc9c2b709f0be9d23ce3c198c33"
-
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
 angular-cli-ghpages@^0.5.0:
   version "0.5.1"
@@ -6248,16 +6244,9 @@ write-file-atomic@^2.0.0:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-ws@1.1.2:
+ws@1.1.2, ws@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.2.tgz#8a244fa052401e08c9886cf44a85189e1fd4067f"
-  dependencies:
-    options ">=0.0.5"
-    ultron "1.0.x"
-
-ws@^1.0.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"

--- a/src/app/input/input.directive.ts
+++ b/src/app/input/input.directive.ts
@@ -1,4 +1,8 @@
 import { Directive, ElementRef, Input, OnInit, Renderer } from '@angular/core';
+import 'rxjs/add/observable/interval';
+import 'rxjs/add/operator/first';
+import 'rxjs/add/operator/skipWhile';
+import { Observable } from 'rxjs/Observable';
 
 import { HandlePropChanges } from '../shared/handle-prop-changes';
 
@@ -76,8 +80,13 @@ export class MzInputDirective extends HandlePropChanges implements OnInit {
     this.renderer.setElementClass(this.inputElement[0], 'autocomplete', isAutocomplete);
 
     if (this.autocomplete != null) {
-      // need setTimeout otherwise loading directly on the page cause an error
-      setTimeout(() => this.renderer.invokeElementMethod(this.inputElement, 'autocomplete', [this.autocomplete]));
+      // wait until autocomplete is defined before to invoke
+      // see issue: https://github.com/Dogfalo/materialize/issues/4401
+      Observable
+        .interval(100)
+        .skipWhile(() => !this.inputElement['autocomplete'])
+        .first()
+        .subscribe(() => this.renderer.invokeElementMethod(this.inputElement, 'autocomplete', [this.autocomplete]));
     }
   }
 

--- a/src/app/input/input.directive.unit.spec.ts
+++ b/src/app/input/input.directive.unit.spec.ts
@@ -273,14 +273,21 @@ describe('MzInputDirective:unit', () => {
           Google: 'http://some-image.png',
         },
       };
-      const mockInputElement = { input: true };
+      const mockInputElement = { input: true, autocomplete: undefined };
 
       directive.inputElement = <any>mockInputElement;
       directive.autocomplete = autocomplete;
       directive.handleAutocomplete();
 
-      tick(1);
+      tick(100);
 
+      expect(directive.inputElement['autocomplete']).toBeUndefined();
+      expect(renderer.invokeElementMethod).not.toHaveBeenCalled();
+
+      mockInputElement.autocomplete = () => null;
+      tick(100);
+
+      expect(directive.inputElement['autocomplete']).toBeDefined();
       expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockInputElement, 'autocomplete', [autocomplete]);
     }));
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5770,16 +5770,9 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-ws@1.1.2:
+ws@1.1.2, ws@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.2.tgz#8a244fa052401e08c9886cf44a85189e1fd4067f"
-  dependencies:
-    options ">=0.0.5"
-    ultron "1.0.x"
-
-ws@^1.0.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"


### PR DESCRIPTION
Fix behavior where loading directly on demo input page ...

- autocomplete would not work and throw an error in console (see Materialize CSS issue: https://github.com/Dogfalo/materialize/issues/4401)
- validation examples would not be highlighted

Note that it all works fine if you navigate to the page instead of loading directly
