### PR TITLE
Fix @types/jquery version missmatch when creating new project

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "heroku-postbuild": "cd demo-app && yarn install && yarn run build:prod"
   },
   "dependencies": {
+    "@types/jquery": "^2.0.47",
     "@types/materialize-css": "0.98.0",
     "materialize-css": "0.98.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,9 +163,9 @@
   version "2.5.45"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.45.tgz#58928a621d014ce6ab59c5a9c41071f7328b0ca9"
 
-"@types/jquery@*":
-  version "2.0.46"
-  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-2.0.46.tgz#c245426299b43c4bb75f44b813090bd5918d00f2"
+"@types/jquery@*", "@types/jquery@^2.0.47":
+  version "2.0.47"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-2.0.47.tgz#9665a157519dd48d259f94ac670d332a56561c00"
 
 "@types/materialize-css@0.98.0":
   version "0.98.0"
@@ -5770,16 +5770,9 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-ws@1.1.2:
+ws@1.1.2, ws@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.2.tgz#8a244fa052401e08c9886cf44a85189e1fd4067f"
-  dependencies:
-    options ">=0.0.5"
-    ultron "1.0.x"
-
-ws@^1.0.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"


### PR DESCRIPTION
Fix `@types/jquery` version missmatch due to `@types/materialize-css` that pulls on the latest version of typing that is made for JQuery 3 (#139)