### PR TITLE
Update docs for tooltip

### DIFF
--- a/demo-app/src/app/tooltip/tooltip.component.html
+++ b/demo-app/src/app/tooltip/tooltip.component.html
@@ -136,7 +136,7 @@
   <app-code-snippet>
 &lt;button mz-button mz-tooltip
   [tooltip]="'I am a custom &lt;b class=\'red-text\'>HTML&lt;/b> tooltip'"
-  [position]="top"
+  [position]="'top'"
   [html]="true"
   [delay]="1000">
   Tooltip


### PR DESCRIPTION
position attribute in the example needs to be a `string`