### PR TITLE
Fix ValidationComponent label element initialization

### DIFF
--- a/src/app/validation/validation.component.ts
+++ b/src/app/validation/validation.component.ts
@@ -113,7 +113,7 @@ export class MzValidationComponent implements AfterViewInit, OnDestroy {
   }
 
   initElements() {
-    this.labelElement = $('label[for=' + this.id + ']')[0];
+    this.labelElement = $('label[for="' + this.id + '"]')[0];
     this.nativeElement = $(this.elementRef.nativeElement);
 
     if (this.isNativeSelectElement) {


### PR DESCRIPTION
Fix behavior where using `mz-validation` on an input that has a special characters such as `:` in `id` property value would throw `unrecognized expression: label[for=foo:bar]`