### PR TITLE
Fix scope for card title and action visibility for nested cards

### DIFF
--- a/src/app/card/card.component.html
+++ b/src/app/card/card.component.html
@@ -4,7 +4,7 @@
 
   <div class="card-content {{ textClass }}">
 
-    <div class="card-title" *ngIf="hasCardTitle">
+    <div #cardTitle class="card-title" *ngIf="hasCardTitle">
       <ng-content select="mz-card-title"></ng-content>
     </div>
 
@@ -13,7 +13,7 @@
     </p>
   </div>
 
-  <div class="card-action" *ngIf="hasCardAction">
+  <div #cardAction class="card-action" *ngIf="hasCardAction">
     <ng-content select="mz-card-action"></ng-content>
   </div>
 </div>

--- a/src/app/card/card.component.ts
+++ b/src/app/card/card.component.ts
@@ -18,6 +18,9 @@ export class MzCardComponent implements AfterViewInit {
   @Input() hoverable: boolean;
   @Input() textClass: string;
 
+  @ViewChild('cardTitle') cardTitle: ElementRef;
+  @ViewChild('cardAction') cardAction: ElementRef;
+
   hasCardAction = true;
   hasCardTitle = true;
 
@@ -33,14 +36,12 @@ export class MzCardComponent implements AfterViewInit {
   }
 
   private hasActionTagAndNotEmpty(): boolean {
-    const cardActionElement = this.elementRef.nativeElement.querySelector('mz-card-action');
-
+    const cardActionElement = this.cardAction.nativeElement.querySelector('mz-card-action');
     return this.isElementDisplayed(cardActionElement);
   }
 
   private hasTitleTagAndNotEmpty(): boolean {
-    const cardTitleElement = this.elementRef.nativeElement.querySelector('mz-card-title');
-
+    const cardTitleElement = this.cardTitle.nativeElement.querySelector('mz-card-title');
     return this.isElementDisplayed(cardTitleElement);
   }
 

--- a/src/app/card/card.component.ts
+++ b/src/app/card/card.component.ts
@@ -26,7 +26,6 @@ export class MzCardComponent implements AfterViewInit {
 
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
-    private elementRef: ElementRef,
   ) {}
 
   ngAfterViewInit() {


### PR DESCRIPTION
Fix behavior with nested `mz-card` components where parent would use child visibilty for `mz-card-title` and `mz-card-action` elements instead of it own scoped elements