### PR TITLE
Refactor Card to use class property instead of input properties

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,7 @@
   // Configure glob patterns for excluding files and folders in searches. Inherits all glob patterns from the file.exclude setting.
   "search.exclude": {
     "**/.tmp": true,
+    "**/coverage": true,
     "**/dist": true,
     "**/inline-template": true
   },

--- a/demo-app/src/app/card/card.component.html
+++ b/demo-app/src/app/card/card.component.html
@@ -86,7 +86,7 @@
   </div>
 
   <p class="col s12 m4 l6">
-    Optionally, colors can be customized using <code class="language-markup">backgroundClass</code> and/or <code class="language-markup">textClass</code> input properties but are <u>not required</u>.<br>
+    Optionally, colors can be customized using <code class="language-markup">class</code> property.<br>
     <br>
     An animation for box-shadow can also be added using <code class="language-markup">hoverable</code> input properties. Roll your cursor over and out of the card to see the animation.
   </p>

--- a/demo-app/src/app/card/card.component.html
+++ b/demo-app/src/app/card/card.component.html
@@ -4,21 +4,22 @@
 
 <div class="row">
 
-  <mz-card class="col s12 m8 l6">
+  <div class="col s12 m8 l6">
+    <mz-card>
+      <mz-card-title>
+        Card Title
+      </mz-card-title>
 
-    <mz-card-title>
-      Card Title
-    </mz-card-title>
+      <mz-card-content>
+        I am a very simple card. I am good at containing small bits of information. I am convenient because I require little markup to use effectively.
+      </mz-card-content>
 
-    <mz-card-content>
-      I am a very simple card. I am good at containing small bits of information. I am convenient because I require little markup to use effectively.
-    </mz-card-content>
-
-    <mz-card-action>
-      <a href="javascript:void(0)">This is a link</a>
-      <a href="javascript:void(0)">This is a link</a>
-    </mz-card-action>
-  </mz-card>
+      <mz-card-action>
+        <a href="javascript:void(0)">This is a link</a>
+        <a href="javascript:void(0)">This is a link</a>
+      </mz-card-action>
+    </mz-card>
+  </div>
 
   <p class="col s12 m4 l6">
     Simple basic card combining title, content and actions.
@@ -29,16 +30,17 @@
 
 <div class="row">
 
-  <mz-card class="col s12 m8 l6">
+  <div class="col s12 m8 l6">
+    <mz-card>
+      <mz-card-title>
+        Card Title
+      </mz-card-title>
 
-    <mz-card-title>
-      Card Title
-    </mz-card-title>
-
-    <mz-card-content>
-      I am a very simple card. I am good at containing small bits of information. I am convenient because I require little markup to use effectively.
-    </mz-card-content>
-  </mz-card>
+      <mz-card-content>
+        I am a very simple card. I am good at containing small bits of information. I am convenient because I require little markup to use effectively.
+      </mz-card-content>
+    </mz-card>
+  </div>
 
   <p class="col s12 m4 l6">
     Action bar won't be displayed if <code class="language-markup">mz-card-action</code> tag is not present or if it does not contain any action.
@@ -49,14 +51,13 @@
 
 <div class="row">
 
-  <mz-card
-    class="col s12 m8 l6"
-    [backgroundClass]="'amber lighten-1'">
-
-    <mz-card-content>
-      I am a very simple card. I am good at containing small bits of information. I am convenient because I require little markup to use effectively.
-    </mz-card-content>
-  </mz-card>
+  <div class="col s12 m8 l6">
+    <mz-card class="amber lighten-1">
+      <mz-card-content>
+        I am a very simple card. I am good at containing small bits of information. I am convenient because I require little markup to use effectively.
+      </mz-card-content>
+    </mz-card>
+  </div>
 
   <p class="col s12 m4 l6">
     Title will also be hidden if <code class="language-markup">mz-card-title</code> tag is not present. This could be usefull to alert the user when combined with appropriate color.
@@ -67,25 +68,22 @@
 
 <div class="row">
 
-  <mz-card
-    class="col s12 m8 l6"
-    [backgroundClass]="'color-hoverable'"
-    [textClass]="'white-text'"
-    [hoverable]="true">
+  <div class="col s12 m8 l6">
+    <mz-card class="color-hoverable white-text" [hoverable]="true">
+      <mz-card-title>
+        Card Title
+      </mz-card-title>
 
-    <mz-card-title>
-      Card Title
-    </mz-card-title>
+      <mz-card-content>
+        I am a very simple card. I am good at containing small bits of information. I am convenient because I require little markup to use effectively.
+      </mz-card-content>
 
-    <mz-card-content>
-      I am a very simple card. I am good at containing small bits of information. I am convenient because I require little markup to use effectively.
-    </mz-card-content>
-
-    <mz-card-action>
-      <a href="javascript:void(0)">This is a link</a>
-      <a href="javascript:void(0)">This is a link</a>
-    </mz-card-action>
-  </mz-card>
+      <mz-card-action>
+        <a href="javascript:void(0)">This is a link</a>
+        <a href="javascript:void(0)">This is a link</a>
+      </mz-card-action>
+    </mz-card>
+  </div>
 
   <p class="col s12 m4 l6">
     Optionally, colors can be customized using <code class="language-markup">backgroundClass</code> and/or <code class="language-markup">textClass</code> input properties but are <u>not required</u>.<br>
@@ -100,8 +98,7 @@
 
 <app-code-snippet>
 &lt;mz-card
-  [backgroundClass]="'blue-grey darken-1'"
-  [textClass]="'white-text'"
+  class="blue-grey darken-1 white-text"
   [hoverable]="true">
   &lt;mz-card-title>
     Card Title

--- a/demo-app/src/app/card/card.component.ts
+++ b/demo-app/src/app/card/card.component.ts
@@ -12,21 +12,11 @@ import { IPropertyRow } from '../shared/properties-table/properties-table.compon
 })
 export class CardComponent {
   properties: IPropertyRow[] = [
-    { name: 'backgroundClass',
-      mandatory: false,
-      type: 'string',
-      description: `Background css class to be applied on the card`,
-    },
     { name: 'hoverable',
       mandatory: false,
       type: 'boolean',
       description: `Box-shadow css animnation on card rollover`,
       defaultValue: `false`,
-    },
-    { name: 'textClass',
-      mandatory: false,
-      type: 'string',
-      description: `Text css class to be applied on the card`,
     },
   ];
 }

--- a/src/app/card/card.component.html
+++ b/src/app/card/card.component.html
@@ -1,19 +1,14 @@
-<div
-  class="card {{ backgroundClass }}"
-  [class.hoverable]="hoverable">
+<div class="card-content">
 
-  <div class="card-content {{ textClass }}">
-
-    <div #cardTitle class="card-title" *ngIf="hasCardTitle">
-      <ng-content select="mz-card-title"></ng-content>
-    </div>
-
-    <p>
-      <ng-content select="mz-card-content"></ng-content>
-    </p>
+  <div #cardTitle class="card-title" *ngIf="hasCardTitle">
+    <ng-content select="mz-card-title"></ng-content>
   </div>
 
-  <div #cardAction class="card-action" *ngIf="hasCardAction">
-    <ng-content select="mz-card-action"></ng-content>
-  </div>
+  <p>
+    <ng-content select="mz-card-content"></ng-content>
+  </p>
+</div>
+
+<div #cardAction class="card-action" *ngIf="hasCardAction">
+  <ng-content select="mz-card-action"></ng-content>
 </div>

--- a/src/app/card/card.component.scss
+++ b/src/app/card/card.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/card/card.component.ts
+++ b/src/app/card/card.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   Directive,
   ElementRef,
+  HostBinding,
   Input,
   ViewChild,
 } from '@angular/core';
@@ -14,9 +15,8 @@ import {
   styleUrls: [ './card.component.scss' ],
 })
 export class MzCardComponent implements AfterViewInit {
-  @Input() backgroundClass: string;
-  @Input() hoverable: boolean;
-  @Input() textClass: string;
+  @HostBinding('class.card') true;
+  @HostBinding('class.hoverable') @Input() hoverable: boolean;
 
   @ViewChild('cardTitle') cardTitle: ElementRef;
   @ViewChild('cardAction') cardAction: ElementRef;

--- a/src/app/card/card.component.view.spec.ts
+++ b/src/app/card/card.component.view.spec.ts
@@ -25,34 +25,31 @@ describe('MzCardComponent:view', () => {
       return nativeElement.querySelector('.card');
     }
 
-    it('should apply backgroundClass css class when provided', async(() => {
+    function mzCard(): HTMLElement {
+      return nativeElement.querySelector('mz-card');
+    }
 
-      buildComponent<MzCardComponent>(`<mz-card [backgroundClass]="'class-x'"></mz-card>`).then((fixture) => {
+    it('should apply css class on mz-card when provided', async(() => {
 
-        nativeElement = fixture.nativeElement;
-        fixture.autoDetectChanges();
-
-        expect(card().classList).toContain('class-x');
-      });
-    }));
-
-    it('should not apply backgroundClass css class when not provided', async(() => {
-
-      buildComponent<MzCardComponent>(`<mz-card></mz-card>`).then((fixture) => {
+      buildComponent<MzCardComponent>(`
+        <mz-card class="class-x"></mz-card>
+      `).then((fixture) => {
 
         const component = fixture.componentInstance;
         nativeElement = fixture.nativeElement;
         fixture.autoDetectChanges();
 
-        expect(component.backgroundClass).toBeUndefined();
-        expect(card().classList.length).toBe(1);
-        expect(card().classList).toContain('card');
+        expect(mzCard().classList.length).toBe(2);
+        expect(mzCard().classList).toContain('card');
+        expect(mzCard().classList).toContain('class-x');
       });
     }));
 
     it('should set hoverable css class when hoverable is true', async(() => {
 
-      buildComponent<MzCardComponent>(`<mz-card [hoverable]="true"></mz-card>`).then((fixture) => {
+      buildComponent<MzCardComponent>(`
+        <mz-card [hoverable]="true"></mz-card>
+      `).then((fixture) => {
 
         nativeElement = fixture.nativeElement;
         fixture.autoDetectChanges();
@@ -63,7 +60,9 @@ describe('MzCardComponent:view', () => {
 
     it('should not set hoverable css class when hoverable is false', async(() => {
 
-      buildComponent<MzCardComponent>(`<mz-card>[hoverable]="false"></mz-card>`).then((fixture) => {
+      buildComponent<MzCardComponent>(`
+        <mz-card [hoverable]="false"></mz-card>
+      `).then((fixture) => {
 
         nativeElement = fixture.nativeElement;
         fixture.autoDetectChanges();
@@ -74,7 +73,9 @@ describe('MzCardComponent:view', () => {
 
     it('should not set hoverable css class when hoverable is not provided', async(() => {
 
-      buildComponent<MzCardComponent>(`<mz-card></mz-card>`).then((fixture) => {
+      buildComponent<MzCardComponent>(`
+        <mz-card></mz-card>
+      `).then((fixture) => {
 
         const component = fixture.componentInstance;
         nativeElement = fixture.nativeElement;
@@ -155,29 +156,26 @@ describe('MzCardComponent:view', () => {
       return nativeElement.querySelector('.card-content');
     }
 
-    it('should apply textClass css class when provided', async(() => {
+    function mzCardContent(): HTMLElement {
+      return nativeElement.querySelector('mz-card-content');
+    }
+
+    it('should apply css class on mz-card-content when provided', async(() => {
 
       buildComponent<MzCardComponent>(`
-        <mz-card [textClass]="'class-x'"></mz-card>`).then((fixture) => {
-
-        nativeElement = fixture.nativeElement;
-        fixture.autoDetectChanges();
-
-        expect(cardContent().classList).toContain('class-x');
-      });
-    }));
-
-    it('should not apply textClass css class when not provided', async(() => {
-
-      buildComponent<MzCardComponent>(`<mz-card></mz-card>`).then((fixture) => {
+        <mz-card>
+          <mz-card-content class="class-x">
+            content-x
+          </mz-card-content>
+        </mz-card>
+      `).then((fixture) => {
 
         const component = fixture.componentInstance;
         nativeElement = fixture.nativeElement;
         fixture.autoDetectChanges();
 
-        expect(component.textClass).toBeUndefined();
-        expect(cardContent().classList.length).toBe(1);
-        expect(cardContent().classList).toContain('card-content');
+        expect(mzCardContent().classList.length).toBe(1);
+        expect(mzCardContent().classList).toContain('class-x');
       });
     }));
 
@@ -188,7 +186,8 @@ describe('MzCardComponent:view', () => {
           <mz-card-content>
             content-x
           </mz-card-content>
-        </mz-card>`).then((fixture) => {
+        </mz-card>
+      `).then((fixture) => {
 
         nativeElement = fixture.nativeElement;
         fixture.autoDetectChanges();
@@ -202,11 +201,11 @@ describe('MzCardComponent:view', () => {
 
     let nativeElement: any;
 
-    function cardActionWrapper(): HTMLElement {
+    function cardAction(): HTMLElement {
       return nativeElement.querySelector('.card-action');
     }
 
-    function cardAction(): HTMLElement {
+    function mzCardAction(): HTMLElement {
       return nativeElement.querySelector('mz-card-action');
     }
 
@@ -217,23 +216,26 @@ describe('MzCardComponent:view', () => {
           <mz-card-action>
             action-x
           </mz-card-action>
-        </mz-card>`).then((fixture) => {
+        </mz-card>
+      `).then((fixture) => {
 
         nativeElement = fixture.nativeElement;
         fixture.autoDetectChanges();
 
-        expect(cardActionWrapper().classList).toContain('card-action');
+        expect(cardAction().classList).toContain('card-action');
       });
     }));
 
     it('should not display when mz-card-action tag is not present', async(() => {
 
-      buildComponent<MzCardComponent>(`<mz-card></mz-card>`).then((fixture) => {
+      buildComponent<MzCardComponent>(`
+        <mz-card></mz-card>
+      `).then((fixture) => {
 
         nativeElement = fixture.nativeElement;
         fixture.autoDetectChanges();
 
-        expect(cardActionWrapper()).toBeFalsy();
+        expect(cardAction()).toBeFalsy();
       });
     }));
 
@@ -242,12 +244,32 @@ describe('MzCardComponent:view', () => {
       buildComponent<MzCardComponent>(`
         <mz-card>
           <mz-card-action></mz-card-action>
-        </mz-card>`).then((fixture) => {
+        </mz-card>
+      `).then((fixture) => {
 
         nativeElement = fixture.nativeElement;
         fixture.autoDetectChanges();
 
-        expect(cardActionWrapper()).toBeFalsy();
+        expect(cardAction()).toBeFalsy();
+      });
+    }));
+
+    it('should apply css class on mz-card-action when provided', async(() => {
+
+      buildComponent<MzCardComponent>(`
+        <mz-card>
+          <mz-card-action class="class-x">
+            action-x
+          </mz-card-action>
+        </mz-card>
+      `).then((fixture) => {
+
+        const component = fixture.componentInstance;
+        nativeElement = fixture.nativeElement;
+        fixture.autoDetectChanges();
+
+        expect(mzCardAction().classList.length).toBe(1);
+        expect(mzCardAction().classList).toContain('class-x');
       });
     }));
 
@@ -258,12 +280,13 @@ describe('MzCardComponent:view', () => {
           <mz-card-action>
             action-x
           </mz-card-action>
-        </mz-card>`).then((fixture) => {
+        </mz-card>
+      `).then((fixture) => {
 
         nativeElement = fixture.nativeElement;
         fixture.autoDetectChanges();
 
-        expect(cardAction().innerText.trim()).toBe('action-x');
+        expect(mzCardAction().innerText.trim()).toBe('action-x');
       });
     }));
   });


### PR DESCRIPTION
Removed `backgroundClass` and `textClass` from `mz-card` component to be able to use `class` directly instead.

⚠️ This brings a breaking change for those using the grid system (classes such as `col s12`) directly on `mz-card` as it adds margin and padding to the applied element. So it would need to be wrapped into a container to apply the grid classes, the same way as it should be done with pure [Materialize card](http://materializecss.com/cards.html).

So it will now need to be used like this...
```html
<div class="col s12">
  <mz-card class="blue-grey darken-1 white-text">
    <mz-card-content>
      Great Content Here.
    </mz-card-content>
  </mz-card>
</div>
```

Fixes #223 