### PR TITLE
Allow sideNav component to utilize routerLink and RouterLinkActive 

### DIFF
--- a/src/app/materialize.module.ts
+++ b/src/app/materialize.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import * as Badge from './badge';
@@ -112,6 +113,7 @@ const MZ_PROVIDERS = [
   imports: [
     CommonModule,
     FormsModule,
+    RouterModule,
   ],
   exports: MZ_COMPONENTS,
   declarations: MZ_COMPONENTS,

--- a/src/app/sidenav/sidenav-link/sidenav-link.component.html
+++ b/src/app/sidenav/sidenav-link/sidenav-link.component.html
@@ -1,5 +1,6 @@
 <li
-  [class.active]="active"
+  [routerLink]="routerLink"
+  routerLinkActive="active"
 >
   <ng-content></ng-content>
 </li>

--- a/src/app/sidenav/sidenav-link/sidenav-link.component.ts
+++ b/src/app/sidenav/sidenav-link/sidenav-link.component.ts
@@ -8,4 +8,5 @@ import { Component, Input, ViewEncapsulation } from '@angular/core';
 })
 export class MzSidenavLinkComponent {
   @Input() active: boolean;
+  @Input() routerLink: string;
 }


### PR DESCRIPTION
This  sets the "active" class is properly set upon navigation using a sideNav link, to enable the background color from Materialize.